### PR TITLE
docs: warn about quoting .env values with special characters & document TLS proxy workaround

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@
 
 # ── Garmin Connect credentials (required for real data) ──────────────────────
 # Without these the app falls back to realistic mock/demo data automatically.
+# ⚠️  If your password contains special characters (like # = $ spaces etc.)
+#     wrap the value in double quotes, e.g.: GARMIN_PASSWORD="myP@ss#123"
 GARMIN_USERNAME=your_garmin_email@example.com
 GARMIN_PASSWORD=your_garmin_password
 
@@ -28,3 +30,9 @@ ANTHROPIC_API_KEY=sk-ant-...
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
 VAPID_EMAIL=mailto:your@email.com
+
+# ── TLS fix (local dev behind corporate proxy / antivirus) ───────────────────
+# Uncomment if you get "self-signed certificate in certificate chain" errors.
+# This is common when your network intercepts HTTPS (Zscaler, Kaspersky, etc.).
+# Only needed for local development — never set this in production.
+# NODE_TLS_REJECT_UNAUTHORIZED=0


### PR DESCRIPTION
```markdown
## Problem

Two common issues cause Garmin login to silently fail during local development:

### 1. Passwords with `#` are silently truncated
dotenv treats `#` as the start of an inline comment, so a password like:
```

GARMIN_PASSWORD=myP@ss#123

```javascript
is read as `myP@ss` — the `#123` is silently discarded. Login fails with no clear error.

**Fix:** Added a warning in `.env.example` to wrap values in double quotes:
```

GARMIN_PASSWORD="myP@ss#123"

```javascript

### 2. "Self-signed certificate in certificate chain" error
Users behind corporate proxies (Zscaler, Fortinet) or antivirus software (Kaspersky, ESET) that perform SSL/TLS inspection will get this error because Node.js rejects the injected certificate.

**Fix:** Added `NODE_TLS_REJECT_UNAUTHORIZED=0` as a documented, commented-out option in `.env.example` that users can enable for local development.

## Changes

- `.env.example` only (documentation — no code changes)
  - ⚠️ Warning about quoting env values containing `#`, `=`, `$`, or spaces
  - `NODE_TLS_REJECT_UNAUTHORIZED=0` as a commented-out option with explanation

## Testing

Verified locally that both fixes resolve the issues and Garmin login succeeds.
```
